### PR TITLE
Citation tweak for Rousslan F. J. Dossa (dosssman), added ORCID link

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,8 +13,9 @@ authors:
 # data contributors and other maintainers
 - family-names: "Raffin" # for contributing SB3's experiments
   given-names: "Antonin"
-- family-names: "Fernand Julien Dossa" # for general contribution of runs from `vwxyzjn/cleanrl`
-  given-names: "Rousslan"
+- family-names: "Dossa" # for general contribution of runs from `vwxyzjn/cleanrl`
+  given-names: "Rousslan Fernand Julien"
+  orcid: "https://orcid.org/0000-0003-0572-692X"
 - family-names: "Zhao" # for contributing experiments to `sdpkjc/abcdrl`
   given-names: "Yanxiao"
 - family-names: "Sullivan" # for contributing SB3 and CleanRL + Dreamerv3 tricks experiments @RyanNavillus


### PR DESCRIPTION
Hello there.

Thanks for adding me to the citation.

Not sure what format is expected for the names, I have edited `family-names` to `Dossa`, added the middles names as `given-names: Rousslan Fernand Julien`, as well as my ORCID profile link.

Thank you for your time.